### PR TITLE
Add address field to sign-up form

### DIFF
--- a/app/controllers/screenings_controller.rb
+++ b/app/controllers/screenings_controller.rb
@@ -2,17 +2,35 @@ class ScreeningsController < ApplicationController
   skip_before_action :authenticate_user!, :only => [:index, :show]
 
   def index
+    @screenings = Screening.all
   end
 
   def show
+    @screening = Screening.find(params[:id])
   end
 
   def new
+    @screening = Screening.new
   end
 
   def create
+    @screening = screening.new(params_screening)
+    authorize @screening
+    if @screening.save
+      redirect_to screen_screening_path(@screening)
+    else
+      render :new
+    end
   end
 
   def destroy
+  end
+
+  private
+
+  def params_screening
+    params.require(:screening).permit(:initial_tickets,
+                                      :detailed_film_id,
+                                      :screen_id, :session_time, :closing_time)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :sold_tickets
-  validates :address, presence: true
+  # validates :address, presence: true
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,7 +1,0 @@
-class UserPolicy < ApplicationPolicy
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
-  end
-end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,7 @@
 
   <div class="form-inputs">
     <%= f.input :email, required: true, autofocus: true %>
+    <%= f.input :address, required: true, autofocus: true %>
     <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) %>
     <%= f.input :password_confirmation, required: true %>
   </div>

--- a/app/views/screenings/index.html.erb
+++ b/app/views/screenings/index.html.erb
@@ -1,2 +1,4 @@
 <h1>Screenings#index</h1>
-<p>Find me in app/views/screenings/index.html.erb</p>
+<p><%= @screenings %></p>
+
+<%= link_to "Screen new", new_screen_screening_path %>


### PR DESCRIPTION
It was not possible to sign-up because the presence of an address was required.
Permitting sign-up without address would need new migrations, so I simply added a new ADDRESS field in the sign-up form. Sign-up working now