### PR TITLE
Create a screening card partial

### DIFF
--- a/app/views/film_titles/index.html.erb
+++ b/app/views/film_titles/index.html.erb
@@ -9,26 +9,10 @@
   <div class="row">
     <% @film_titles.each do |film| %>
       <% film.screenings.each do |screening| %>
-        <div class="col-xs-12 col-sm-4 col-md-4">
-          <div class="screening">
-            <%= link_to screening_path(screening) do %>
-              <%# TODO: CSS this p tag %>
-              <p><%= film.title %></p>
-              <div class="screening-img">
-                 <%= image_tag "https://image.tmdb.org/t/p/w200#{film.img_url}" %>
-              </div>
-              <div class='screening-info'>
-                <p><%= screening.session_time.strftime("%d/%m/%Y, %H:%M") %></p>
-                <p><em><%= screening.screen.name %></em></p>
-                <p>Ingressos disponíveis: <strong>
-                  <%= screening.initial_tickets - screening.tickets.count %>
-                  </strong>
-                </p>
-                <p>A partir de R$ <%= Money.new(screening.calculate_price(Time.now), 'BRL') %> - compre já!</p>
-              </div>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'screenings/screening_card',
+                   screening: screening,
+                   film: film,
+                   display_title: true %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/screenings/_screening_card.html.erb
+++ b/app/views/screenings/_screening_card.html.erb
@@ -1,0 +1,20 @@
+<div class="col-xs-12 col-sm-4 col-md-4">
+  <div class="screening">
+    <%= link_to screening_path(screening) do %>
+      <%# TODO: CSS this p tag %>
+      <p><%= film.title if display_title %></p>
+      <div class="screening-img">
+         <%= image_tag "https://image.tmdb.org/t/p/w200#{film.img_url}" %>
+      </div>
+      <div class='screening-info'>
+        <p><%= screening.session_time.strftime("%d/%m/%Y, %H:%M") %></p>
+        <p><em><%= screening.screen.name %></em></p>
+        <p>Ingressos disponíveis: <strong>
+          <%= screening.initial_tickets - screening.tickets.count %>
+          </strong>
+        </p>
+        <p>A partir de R$ <%= Money.new(screening.calculate_price(Time.now), 'BRL') %> - compre já!</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/screenings/show.html.erb
+++ b/app/views/screenings/show.html.erb
@@ -42,21 +42,10 @@
   <h3>Outras sessões do filme: <%= @screening.detailed_film.film_title.title %></h3>
   <div class="row">
     <% @film_title.screenings.each do |screening| %>
-      <div class="col-xs-12 col-sm-4 col-md-4">
-        <div class="screening">
-          <a href=<%= screening_path(screening) %>>
-            <div class="screening-img">
-              <img src=<%= screening.screen.screen_img %>>
-            </div>
-            <div class='screening-info'>
-              <p><%= screening.detailed_film.film_title.title %></p>
-              <p>Horário: <%= screening.session_time.strftime("%H:%M") %></p>
-              <p><%= screening.screen.name %></p>
-              <p>Ingressos disponíveis: <%= screening.initial_tickets - screening.tickets.count %></p>
-            </div>
-          </a>
-        </div>
-      </div>
+      <%= render 'screenings/screening_card',
+                 screening: screening,
+                 film: @screening.detailed_film.film_title,
+                 display_title: false %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This segregates the screening card code into its own partial, to be rendered by other files that need it.
I've only added the render helper to film_titles#index and screenings#show, there might be other use cases.